### PR TITLE
feat: Add support for interactive video segment branching

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -28,7 +28,6 @@
         video {
             width: 100%;
             display: block;
-            /* Remove extra space below video */
         }
 
         .ivl-interaction-overlay {
@@ -56,9 +55,6 @@
             color: white;
             border: none;
             padding: 10px 20px;
-            text-align: center;
-            text-decoration: none;
-            display: inline-block;
             font-size: 16px;
             margin-top: 15px;
             cursor: pointer;
@@ -67,13 +63,6 @@
 
         .ivl-interaction-overlay button:hover {
             background-color: #45a049;
-        }
-
-        video {
-            max-width: 800px;
-            width: 100%;
-            border: 1px solid #ccc;
-            box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
         }
 
         .controls {
@@ -123,7 +112,8 @@
             videoUrl: 'https://interactive-video-labs.github.io/assets/sample-video.mp4',
             cues: [
                 { id: 'intro', time: 2, label: 'Introduction', payload: { message: 'Welcome!' } },
-                { id: 'question1', time: 5, label: 'Question 1', payload: { interaction: { type: 'choice', title: 'Quick Question', description: 'Please select the correct answer.', question: 'What is 2+2?', options: ['3', '4', '5'] } } },
+                { id: 'question1', time: 5, label: 'Question 1', payload: { interaction: { type: 'choice', title: 'Quick Question', description: 'Please select the correct answer.', question: 'What is 2+2?', options: ['3', '4', '5'], correctAnswer: '4' } } },
+                { id: 'segmentChange', time: 10, label: 'Segment Change', payload: { interaction: { type: 'choice-video-segment-change', title: 'Choose your path', description: 'Select a video segment to jump to.', question: 'Where would you like to go?', options: [{ level: 'Segment A', video: 'https://interactive-video-labs.github.io/assets/sample-interaction-1.mp4' }, { level: 'Segment B', video: 'https://interactive-video-labs.github.io/assets/sample-interaction-2.mp4' }] } } },
                 { id: 'midpoint', time: 8, label: 'Midpoint', payload: { message: 'Halfway there!' } },
                 { id: 'question2', time: 12, label: 'Question 2', payload: { interaction: { type: 'text', title: 'Your Information', description: 'Please enter your name below.', question: 'Your name?' } } },
                 { id: 'end', time: 15, label: 'End', payload: { message: 'Thanks for watching!' } },
@@ -133,15 +123,12 @@
 
         let player = new IVLabsPlayer('player-container', playerConfig);
 
-        // Log events to the console and HTML
         const log = (message) => {
             console.log(message);
             logElement.innerHTML += `<p>${message}</p>`;
-            logElement.scrollTop = logElement.scrollHeight; // Scroll to bottom
+            logElement.scrollTop = logElement.scrollHeight;
         };
 
-        // Example of how to interact with the player's event system (if exposed)
-        // For now, we'll just log internal analytics events
         player.analytics.onTrack((event, payload) => {
             log(`Analytics Event: ${event} - ${JSON.stringify(payload)}`);
         });
@@ -150,15 +137,6 @@
             log(`Interaction Prompt: ${payload.question} (Cue: ${cue.id})`);
         });
 
-        player.interactionManager.onResponse((response, cue) => {
-            log(`Interaction Response: ${response} (Cue: ${cue.id})`);
-            player.play(); // Resume playback
-            // After interaction, transition back to playing (if player supports it)
-            // This part depends on how you design your state machine and player logic
-            // For this example, we'll just log it.
-        });
-
-        // Basic controls
         document.getElementById('playButton').addEventListener('click', () => {
             player.play();
         });
@@ -170,8 +148,6 @@
         document.getElementById('destroyButton').addEventListener('click', () => {
             player.destroy();
             log('Player destroyed.');
-            // Re-initialize for testing if needed
-            // player = new IVLabsPlayer(videoElement, playerConfig);
         });
 
         log('IVLabsPlayer initialized.');

--- a/src/player.ts
+++ b/src/player.ts
@@ -137,21 +137,7 @@ export class IVLabsPlayer {
     this.videoElement.pause()
   }
 
-  /**
-   * Replaces the main video with a new video source.
-   * @param newVideoUrl - The URL of the new video to load.
-   * @param startTime - Optional: The time in seconds to start the new video from. Defaults to 0.
-   */
-  public replaceMainVideo(newVideoUrl: string, startTime: number = 0): void {
-    this.videoElement.pause();
-    this.videoElement.src = newVideoUrl;
-    this.videoElement.currentTime = startTime;
-    this.videoElement.load();
-    this.videoElement.play().catch(error => {
-      console.error('Error playing new main video:', error);
-    });
-    
-  }
+
 
   /** Cleans up the player, removes listeners and resets state. */
   public destroy(): void {

--- a/src/segmentManager.ts
+++ b/src/segmentManager.ts
@@ -1,0 +1,67 @@
+import { HTMLVideoElementWithControlsList } from './types';
+
+/**
+ * Manages the logic for switching to and from video segments.
+ */
+export class SegmentManager {
+  private videoElement: HTMLVideoElementWithControlsList;
+  private _mainVideoSrc: string | null = null;
+  private _mainVideoCurrentTime: number = 0;
+
+  constructor(videoElement: HTMLVideoElementWithControlsList) {
+    this.videoElement = videoElement;
+    this.bindEvents();
+  }
+
+  private bindEvents(): void {
+    this.videoElement.addEventListener('ended', () => {
+      if (this._mainVideoSrc) {
+        console.log('Segment ended. Resuming main video:', this._mainVideoSrc);
+
+        const resumeSrc = this._mainVideoSrc;
+        const resumeTime = this._mainVideoCurrentTime;
+
+        this._mainVideoSrc = null;
+        this._mainVideoCurrentTime = 0;
+
+        this.videoElement.src = resumeSrc;
+        this.videoElement.load();
+
+        this.videoElement.addEventListener('loadedmetadata', () => {
+          this.videoElement.currentTime = resumeTime;
+          this.videoElement.play().catch(err => {
+            console.error('Error resuming main video:', err);
+          });
+        }, { once: true });
+      }
+    });
+  }
+
+  /**
+   * Handles the transition to a new video segment.
+   * Saves the current main video state and plays the new segment.
+   * @param newSegmentUrl The URL of the new video segment to play.
+   */
+  public playSegment(newSegmentUrl: string): void {
+    this._mainVideoSrc = this.videoElement.src;
+    this._mainVideoCurrentTime = this.videoElement.currentTime;
+
+    this.videoElement.src = newSegmentUrl;
+    this.videoElement.load();
+    this.videoElement.addEventListener('loadedmetadata', () => {
+      this.videoElement.play().catch(error => {
+        console.error('Error playing segment video:', error);
+      });
+      console.log('Playing segment video:', newSegmentUrl);
+    }, { once: true });
+  }
+
+  /**
+   * Destroys the SegmentChangeManager instance.
+   * Removes event listeners.
+   */
+  public destroy(): void {
+    // No specific cleanup needed for event listeners added with { once: true }
+    // If other persistent listeners were added, they would be removed here.
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,3 @@
-
 /**
  * Interactive Video Labs Player Types
  * This file defines the types and interfaces used in the IVLabsPlayer.
@@ -8,7 +7,7 @@
 
 
 export type PlayerConfig = {
-  videoUrl: string
+  videoUrl?: string
   cues?: CuePoint[]
   subtitlesUrl?: string
   localization?: LocalizationStrings
@@ -61,13 +60,19 @@ export interface AnalyticsHook {
   (payload: AnalyticsPayload): void
 }
 
+export type ChoiceVideoSegmentChangeOption = {
+  level: string
+  video: string
+}
+
 export type InteractionPayload = {
-  type: 'choice' | 'text' | 'rating'
+  type: 'choice' | 'text' | 'rating' | 'choice-video-segment-change'
   title?: string
   description?: string
   question: string
-  options?: string[]
+  options?: string[] | ChoiceVideoSegmentChangeOption[]
   correctAnswer?: string
+  response?: Record<string, any>
 }
 
 export type PlayerEvent =
@@ -78,6 +83,7 @@ export type PlayerEvent =
   | 'interaction'
   | 'branch'
   | 'error'
+  | 'segmentchange'
 
 
 export type InteractionSegment = {
@@ -88,3 +94,7 @@ export type InteractionSegment = {
 }
 
 export type PlayerState = 'idle' | 'playing' | 'waitingForInteraction' | 'ended' | 'error'
+
+export interface HTMLVideoElementWithControlsList extends HTMLVideoElement {
+  controlsList: string;
+}

--- a/test/interactionManager.test.ts
+++ b/test/interactionManager.test.ts
@@ -115,7 +115,7 @@ describe('InteractionManager', () => {
     const consoleSpy = vi.spyOn(console, 'log');
     const interactions = [{ id: 'int1' }, { id: 'int2' }];
     interactionManager.loadInteractions(interactions);
-    expect(consoleSpy).toHaveBeenCalledWith('Loading interactions:', interactions);
+    expect(consoleSpy).toHaveBeenCalledWith('Interactions loaded into store:', expect.any(Map));
     consoleSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## ✨ Summary

This PR implements **video segment branching** based on user interactions, resolving [#13](https://github.com/interactive-video-labs/core/issues/13).  
Users can now select different paths during playback that load and play alternate video segments.

---

## ✅ Key Features

- **SegmentManager**
  - Introduced a new `SegmentManager` class that handles video source changes and resumes playback.

- **Enhanced InteractionManager**
  - Supports a new interaction type: `choice-video-segment-change`.
  - Routes user choices to corresponding video segments.
  - Internally stores and manages interaction metadata.

- **Player Integration**
  - Seamlessly integrates `SegmentManager` for dynamic video switching.
  - Automatically resumes playback post-segment switch unless paused by the interaction.

- **Type Updates**
  - Extended type definitions in `types.ts` to support segment-based interactions and new payload structures.

- **Updated Example**
  - Demo HTML includes branching interaction logic.
  - Logs user interactions and transitions to showcase the new feature.

---

## 📽️ Use Case Example

At a defined cue (e.g., `time: 10s`), users are prompted to choose:
- Segment A → loads `sample-interaction-1.mp4`
- Segment B → loads `sample-interaction-2.mp4`

Playback then continues from the selected segment.

---

## 🧪 Testing

- Verified interaction flow via the provided HTML example.
- Manual testing done for:
  - Segment change flow
  - Fallback to main video
  - Accurate cue triggering
  - Clean transition handling

---

## 🔒 Backwards Compatibility

✅ Fully backwards compatible with existing interaction types and cue systems.

---

Closes #13
