### PR TITLE
ci: add major/minor release heading in GitHub release notes

### DIFF
--- a/.github/workflows/tag-after-merge.yml
+++ b/.github/workflows/tag-after-merge.yml
@@ -80,10 +80,12 @@ jobs:
 
       - name: Create GitHub Release
         if: env.release_type != 'patch'
-        uses: actions/create-release@v1
+      - name: Create GitHub Release
+        if: env.release_type != 'patch'
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: v${{ env.version }}
-          release_name: "Release v${{ env.version }}"
+          name: "Release v${{ env.version }}"
           body: ${{ env.notes }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Updated release notes extraction to prepend heading based on release type
  - 🚀 Major Release
  - ✨ Minor Release
- Adjusted awk logic to parse changelog entries formatted as "## vX.Y.Z YYYY MM DD"
- Ensures GitHub release body includes contextual heading + changelog content

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically creates GitHub Releases for major and minor versions after merge, including release notes extracted from the changelog.
  * Patch releases remain tag-only, preserving current behavior.

* **Chores**
  * Updated CI workflow name, job name, and log messages to reflect the new tag-and-release process.
  * Adjusted workflow permissions to support release creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->